### PR TITLE
Add wait dialog before GDM for live-guest. Fix some issues with the mount.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/imedias/live-guest
 
 Package: live-guest
 Architecture: all
-Depends: consolekit, bindfs (>= 1.10.1), passwd, adduser, eject, procps, user-setup, libpam-script (>> 1.1.5-1), sqlite3, ${misc:Depends}
+Depends: bindfs (>= 1.10.1), passwd, adduser, eject, procps, user-setup, libpam-script (>> 1.1.5-1), sqlite3, python2.7-minimal, python-gi, ${misc:Depends}
 Description: Debian Live - Guest System for removable Debian Live media
  live-guest configures your system to automatically mount Debian Live
  systems plugged into your system on removable media. After mounting

--- a/debian/live-guest.install
+++ b/debian/live-guest.install
@@ -6,3 +6,5 @@ debian/99_live-guest                etc/default/kdm.d
 10_replace_userid                   usr/share/live-guest/mount.d
 10_fixup_kde                        usr/share/live-guest/mount.d
 debian/live-guest@.service          lib/systemd/system
+wait_dialog/wait_dialog.py          usr/share/live-guest/wait_dialog
+wait_dialog/dialog.glade            usr/share/live-guest/wait_dialog

--- a/debian/live-guest.postinst
+++ b/debian/live-guest.postinst
@@ -45,8 +45,13 @@ case "$1" in
                 echo "live-guest" > /var/lib/live/config/gdm3
                 echo "done."
             fi
-        fi
 
+            # show wait dialog before GDM start
+            if ! grep -e "wait_dialog" /etc/gdm3/Init/Default ; then
+                sed -i 's|^exit 0$|xsetroot -cursor_name left_ptr\n/usr/share/live-guest/wait_dialog/wait_dialog.py\nexit 0|' \
+                    /etc/gdm3/Init/Default
+            fi
+        fi
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/mount
+++ b/mount
@@ -50,7 +50,8 @@ fi
 log notice "Checking disk ${DEVNAME} for Debian Live system."
 
 # Check if a user session is running, exit if someone is logged in
-if [ $(ck-list-sessions | grep realname | grep -cv "Gnome Display Manager") -gt 0 ] ; then
+SESSION_ID=$(loginctl list-sessions | grep 1000 | tr -s ' ' | cut -d' ' -f 2)
+if loginctl show-session "$SESSION_ID" 2>/dev/null | grep "Service=gdm" >/dev/null; then
     log notice "A user session is running, exiting."
     exit 0
 fi
@@ -199,7 +200,8 @@ if [ ! -d "${MOUNT_ROOT_DIR}"/home/user -a -x "${USER_SETUP_SCRIPT}" ] ; then
 fi
 
 # create guest user if it does not yet exist
-getent passwd ${USER} > /dev/null || useradd -p "" ${USER} && log debug "Created Guest Live user."
+getent passwd ${USER} > /dev/null || useradd -p "" ${USER} -s /bin/bash \
+  && log debug "Created Guest Live user."
 
 # Add user the default groups, get groups from debconf database
 groups=$(echo "GET passwd/user-default-groups" | debconf-communicate | cut -c3- )

--- a/wait_dialog/README.md
+++ b/wait_dialog/README.md
@@ -1,0 +1,5 @@
+Copy the `wait_dialog` dir to `/usr/share/live-guest/wait_dialog` and add the
+following lines to `/etc/gdm3/Init/Default`:
+
+    xsetroot -cursor_name X_cursor
+    /usr/share/live-guest/wait_dialog/wait_dialog.py

--- a/wait_dialog/dialog.glade
+++ b/wait_dialog/dialog.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.20.0 -->
 <interface>
-  <requires lib="gtk+" version="3.0"/>
+  <requires lib="gtk+" version="3.8"/>
   <object class="GtkWindow" id="wait_dialog">
     <property name="can_focus">False</property>
     <property name="default_width">400</property>
@@ -19,6 +19,7 @@
             <property name="height_request">44</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
+            <property name="has_focus">True</property>
             <property name="receives_default">True</property>
             <signal name="clicked" handler="on_continue_without_stick_clicked" swapped="no"/>
           </object>
@@ -53,17 +54,6 @@
           </object>
           <packing>
             <property name="x">79</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkEntry">
-            <property name="width_request">168</property>
-            <property name="height_request">64</property>
-            <property name="can_focus">True</property>
-          </object>
-          <packing>
-            <property name="x">100</property>
-            <property name="y">240</property>
           </packing>
         </child>
       </object>

--- a/wait_dialog/dialog.glade
+++ b/wait_dialog/dialog.glade
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
+<interface>
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkWindow" id="wait_dialog">
+    <property name="can_focus">False</property>
+    <property name="default_width">400</property>
+    <property name="default_height">250</property>
+    <child>
+      <object class="GtkLayout" id="layout1">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="width">0</property>
+        <property name="height">0</property>
+        <child>
+          <object class="GtkButton" id="continue_without_stick">
+            <property name="label" translatable="yes">Ohne Lernstick fortfahren</property>
+            <property name="width_request">234</property>
+            <property name="height_request">44</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <signal name="clicked" handler="on_continue_without_stick_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="x">63</property>
+            <property name="y">104</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinner" id="spinner">
+            <property name="width_request">100</property>
+            <property name="height_request">41</property>
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="active">True</property>
+          </object>
+          <packing>
+            <property name="x">126</property>
+            <property name="y">53</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="width_request">203</property>
+            <property name="height_request">55</property>
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Warte auf Lernstick...</property>
+            <attributes>
+              <attribute name="font-desc" value="Bitstream Vera Sans Bold 13"/>
+            </attributes>
+          </object>
+          <packing>
+            <property name="x">79</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry">
+            <property name="width_request">168</property>
+            <property name="height_request">64</property>
+            <property name="can_focus">True</property>
+          </object>
+          <packing>
+            <property name="x">100</property>
+            <property name="y">240</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/wait_dialog/wait_dialog.py
+++ b/wait_dialog/wait_dialog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2
 CHECK_FREQUENCY = 1  # seconds
-LOG_TO_SYSLOG = True
+LOG_TO_SYSLOG = False
 
 import os
 from subprocess import Popen, PIPE

--- a/wait_dialog/wait_dialog.py
+++ b/wait_dialog/wait_dialog.py
@@ -18,6 +18,7 @@ handlers = {
 builder.connect_signals(handlers)
 w = builder.get_object('wait_dialog')
 w.resize(370, 170)
+w.set_position(Gtk.WindowPosition.CENTER)
 w.show_all()
 
 def log(msg):

--- a/wait_dialog/wait_dialog.py
+++ b/wait_dialog/wait_dialog.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python2
+CHECK_FREQUENCY = 1  # seconds
+LOG_TO_SYSLOG = True
+
+import os
+from subprocess import Popen, PIPE
+
+import gi
+from gi.repository import Gtk, GLib
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+
+builder = Gtk.Builder()
+builder.add_from_file(script_dir + '/dialog.glade')
+handlers = {
+    "on_continue_without_stick_clicked": Gtk.main_quit,
+}
+builder.connect_signals(handlers)
+w = builder.get_object('wait_dialog')
+w.resize(370, 170)
+w.show_all()
+
+def log(msg):
+    print(msg)
+    if LOG_TO_SYSLOG:
+        p = Popen(['/usr/bin/logger', '-t', 'live-guest-wait', '-p', 'user.notice'],
+                  stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        p.communicate(msg)
+
+def check():
+    log("Checking...")
+    if 0 == os.system("id live-guest 2>/dev/null"):
+        log("Live-guest mounted, exiting!")
+        Gtk.main_quit() 
+    GLib.timeout_add_seconds(CHECK_FREQUENCY, check)
+
+GLib.timeout_add_seconds(CHECK_FREQUENCY, check)
+Gtk.main()


### PR DESCRIPTION
This fixes two minor issues with the existing code:
- GDM does not use consolekit any more. Instead we can now use loginctl to figure out if a session is running
- The `live-guest` user is added with `/bin/sh` as a login shell. Changed to `/bin/bash`.

This branch also adds a small Python GUI that will be shown before the login screen. It waits for a live stick to be inserted, then lets you log in as the guest user.
## Potential improvements
- wait dialog: Immediately give feedback after stick is inserted. For example we can wait for the lock file and then change the text from "Warten auf Lernstick..." to "Richte Lernstick ein...", and then continue with the login manager if the guest user creation is finished
- localization of the wait dialog
- Allow for encrypted data partitions: We will have to show a simple UI to enter the disk password, then mount
- Can we adapt this for KDE?
